### PR TITLE
chore(ci): bump actions to latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   DOCKERHUB_IMAGE: amayer1983/docksentry
-  GHCR_IMAGE: ghcr.io/amayer1983/docksentry
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/docksentry
 
 jobs:
   build-and-push:
@@ -19,19 +19,33 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
+
+      - name: Check Docker Hub credentials
+        id: dockerhub-check
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [[ -n "$DOCKERHUB_USERNAME" && -n "$DOCKERHUB_TOKEN" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets are not set, skipping Docker Hub login and push."
+          fi
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        if: steps.dockerhub-check.outputs.enabled == 'true'
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,26 +53,32 @@ jobs:
 
       - name: Extract version from tag
         id: meta
+        env:
+          DOCKERHUB_ENABLED: ${{ steps.dockerhub-check.outputs.enabled }}
         run: |
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "tags<<EOF" >> $GITHUB_OUTPUT
-            echo "${{ env.DOCKERHUB_IMAGE }}:latest" >> $GITHUB_OUTPUT
-            echo "${{ env.DOCKERHUB_IMAGE }}:$VERSION" >> $GITHUB_OUTPUT
+            if [[ "$DOCKERHUB_ENABLED" == "true" ]]; then
+              echo "${{ env.DOCKERHUB_IMAGE }}:latest" >> $GITHUB_OUTPUT
+              echo "${{ env.DOCKERHUB_IMAGE }}:$VERSION" >> $GITHUB_OUTPUT
+            fi
             echo "${{ env.GHCR_IMAGE }}:latest" >> $GITHUB_OUTPUT
             echo "${{ env.GHCR_IMAGE }}:$VERSION" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
           else
             echo "version=dev" >> $GITHUB_OUTPUT
             echo "tags<<EOF" >> $GITHUB_OUTPUT
-            echo "${{ env.DOCKERHUB_IMAGE }}:dev" >> $GITHUB_OUTPUT
+            if [[ "$DOCKERHUB_ENABLED" == "true" ]]; then
+              echo "${{ env.DOCKERHUB_IMAGE }}:dev" >> $GITHUB_OUTPUT
+            fi
             echo "${{ env.GHCR_IMAGE }}:dev" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
bump actions to latest recommended, removes a nodejs v20 warning.
Add guard if docker hub secrets not in place not to login to dockerhub
Update GHCR env to be based off github repo owner, makes building in forked repo easier.
